### PR TITLE
Fix DOF Calculation for AROMA Strategy in calculate_degrees_of_freedom_test_noboldpreproc_aromafix.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ participants.tsv
 featured.png
 # HCP
 logs/
+outputs*/
 
 # Jupyterbook
 content/_build

--- a/fmriprep_denoise/features/build_features_test.py
+++ b/fmriprep_denoise/features/build_features_test.py
@@ -223,6 +223,9 @@ def main():
     if metric_option == "connectome":
         collection_metric.columns = used_strategy_names
         logging.debug("Columns set to used strategy names for connectome metric.")
+        print("collection_metric shape:", collection_metric.shape)
+        print("collection_metric preview:")
+        print(collection_metric.head())
 
     output_file = output_path / f"dataset-{dataset}_atlas-{atlas}_nroi-{dimension}_{metric_option}.tsv"
     collection_metric.to_csv(output_file, sep="\t")

--- a/scripts/slurm_meta_confounds_test.sh
+++ b/scripts/slurm_meta_confounds_test.sh
@@ -118,13 +118,13 @@ find /home/seann/scratch/halfpipe_test/test15/derivatives/fmriprep -type f -name
 done
 
 
-# Call the updated script that relies only on confounds files.
-python calculate_degrees_of_freedom_test_noboldpreproc_1.py \
-    /home/seann/scratch/denoise/fmriprep-denoise-benchmark/outputs/denoise-metrics-atlas.5-4.27.25/ds000228/fmriprep-20.2.7 \
-    --fmriprep_path=/home/seann/scratch/halfpipe_test/test15/derivatives/fmriprep \
-    --dataset_name=ds000228 \
-    --specifier=task-pixar \
-    --participants_tsv /home/seann/projects/def-cmoreau/All_user_common_folder/datasets/ds000228/participants.tsv
+# # Call the updated script that relies only on confounds files.
+# python calculate_degrees_of_freedom_test_noboldpreproc_1.py \
+#     /home/seann/scratch/denoise/fmriprep-denoise-benchmark/outputs/denoise-metrics-atlas.5-4.27.25/ds000228/fmriprep-20.2.7 \
+#     --fmriprep_path=/home/seann/scratch/halfpipe_test/test15/derivatives/fmriprep \
+#     --dataset_name=ds000228 \
+#     --specifier=task-pixar \
+#     --participants_tsv /home/seann/projects/def-cmoreau/All_user_common_folder/datasets/ds000228/participants.tsv
 
 # # Call the updated script that relies only on confounds files.
 # python calculate_degrees_of_freedom_test_noboldpreproc_1.py \
@@ -133,3 +133,20 @@ python calculate_degrees_of_freedom_test_noboldpreproc_1.py \
 #     --dataset_name=ds000228 \
 #     --specifier=task-pixar \
 #     --participants_tsv /home/seann/projects/def-cmoreau/All_user_common_folder/datasets/ds000228/participants.tsv
+
+
+# Call the updated script that relies only on confounds files.
+# python calculate_degrees_of_freedom_test_noboldpreproc_aromafix.py \
+#     /home/seann/scratch/denoise/fmriprep-denoise-benchmark/outputs/denoise-metrics-atlas.5-4.27.25/ds000228/fmriprep-25.0.0 \
+#     --fmriprep_path=/home/seann/scratch/halfpipe_test/test14/derivatives/fmriprep \
+#     --dataset_name=ds000228 \
+#     --specifier=task-pixar \
+#     --participants_tsv /home/seann/projects/def-cmoreau/All_user_common_folder/datasets/ds000228/participants.tsv
+
+# Call the updated script that relies only on confounds files.
+python calculate_degrees_of_freedom_test_noboldpreproc_aromafix.py \
+    /home/seann/scratch/denoise/fmriprep-denoise-benchmark/outputs/denoise-metrics-atlas.5-4.27.25/ds000228/fmriprep-20.2.7 \
+    --fmriprep_path=/home/seann/scratch/halfpipe_test/test15/derivatives/fmriprep \
+    --dataset_name=ds000228 \
+    --specifier=task-pixar \
+    --participants_tsv /home/seann/projects/def-cmoreau/All_user_common_folder/datasets/ds000228/participants.tsv


### PR DESCRIPTION
### Summary

This PR fixes an issue in `calculate_degrees_of_freedom_test_noboldpreproc_aromafix.py` where the degrees of freedom (DOF) calculation did not correctly account for the AROMA components when using the AROMA strategy.

### Changes Made
- Added logic to load `*_desc-aroma_timeseries.tsv` files when the strategy is AROMA. These files are grabbed from HALFpipe derivatives folder instead of from fmriprep derivatives.
- Adjusted the DOF calculation to include the number of columns (components) in the AROMA file as regressors.
- Minor logging updates for clarity during processing.

### Testing
- Verified that the new AROMA DOF values match expectations across multiple subjects.
- Confirmed other strategies (`simple`, `compcor`, etc.) DOF values match expectations.

### Next Steps
- Review and merge into `main`.

--